### PR TITLE
Add a button to window the spidertron on map

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -174,6 +174,15 @@ do
       })
       home_button.style.height = 28
       home_button.style.width = 28
+
+      local map_button = spidertron_flow.add({
+        type = "sprite-button",
+        sprite = "entity/radar",
+        tags = {["scc-action"] = "window_spidertron", ["scc-unit-number"] = spidertron.unit_number},
+        tooltip = {"tooltip.map-view"}
+      })
+      map_button.style.height = 28
+      map_button.style.width = 28
     end
 
     -- Show frame if there's something to show
@@ -205,6 +214,10 @@ do
     global.path_requests[path_request_id] = { spidertron = spidertron_entity, request = request }
   end
 
+  local function window_spidertron(spidertron_entity, player)
+    player.open_map(spidertron_entity.position, .1)
+  end
+
   script.on_event(defines.events.on_gui_click, function(event)
     local action = event.element.tags["scc-action"]
     if not action then
@@ -233,6 +246,9 @@ do
       end
     end
 
+    if action == "window_spidertron" then
+      window_spidertron(spidertron, player)
+    end
     if action == "remote" then
       global.follow_after_autopilot[spidertron.unit_number] = nil
       local cursor = player.cursor_stack

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -8,6 +8,7 @@ scc-toggle-frame=Toggle spidertron control center
 remote=Get a temporary remote for this spidertron
 call-to-player=Call the spidertron to your current location. Hold shift to make it follow you on arrival.
 call-to-home=Call the spidertron home. Hold shift to set a new home location.
+map-view=Show the spidertron on the map.
 
 [frame]
 title=Spidertron control center


### PR DESCRIPTION
Added a radar icon button that allows the user to display the selected spidertron on the map, so they can find it easier. 
 
 **Use Case:**
_As a user, I constantly send various spidertrons to go out and build or resupply artillery outposts, or send out to build resource acquisition sites. While multitasking, I lose track of where the spidertrons are and it is difficult to see them on the map, so I need a way to automatically find them._ 