### PR TITLE
Update request_path param label

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -262,7 +262,7 @@ do
       start = spidertron_entity.position,
       goal = target_position,
       force = spidertron_entity.force,
-      pathfinder_flags = {
+      pathfind_flags = {
         prefer_straight_paths = true
       }
     }


### PR DESCRIPTION
I wanted to disable path caching for my local version of the mod so I went to edit the code and noticed that the param was named `pathfinder_flags`, which isn't recognized by the Lua API ([reference here](https://lua-api.factorio.com/latest/LuaSurface.html#LuaSurface.request_path)).

This PR updates the param name to `pathfind_flags`, which is recognized by the API.  Spidertron pathing became noticeably better after making this change to my local version.

I'd also like to propose adding the param `cache = false` in a future update as spidertron units will often use cached paths even if a much shorter path is available after a surface change (like filling in a bunch of water with landfill).  

